### PR TITLE
Fix parse_move imports in tests

### DIFF
--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -3,7 +3,7 @@ import sys, os
 import pytest
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from othello.board import BitBoard, parse_move
+from othello.board import BitBoard
 from othello.ai import choose_move
 from othello.cli import run_game
 

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -3,9 +3,9 @@ import sys, os
 import pytest
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from othello.board import BitBoard
+from othello.board import BitBoard, parse_move
 from othello.ai import choose_move
-from othello.cli import run_game, parse_move
+from othello.cli import run_game
 
 
 def test_ai_move_is_legal():

--- a/tests/test_board_extra.py
+++ b/tests/test_board_extra.py
@@ -3,8 +3,7 @@ import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from othello.board import BitBoard
-from othello.cli import parse_move
+from othello.board import BitBoard, parse_move
 
 
 def mask_from_ascii(board_str: str) -> int:


### PR DESCRIPTION
## Summary
- update imports in tests to use `parse_move` from `othello.board`
- ensure all tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686794c29de083259b88fc0a1ba3f73b