### PR TITLE
Fix edge move detection

### DIFF
--- a/MEMO.md
+++ b/MEMO.md
@@ -22,3 +22,4 @@
 2025-07-16: モジュール構成を整理しARCHITECT.mdに反映。board/ai/cli/gui/networkの役割を明記した。
 2025-07-17: ARCHITECT.mdにあるべき姿を示すTODOセクションを追加。
 2025-07-18: CLI/GUIから独立したGameクラスをgame.pyに追加し、履歴管理とUndo/Redoを委譲した。
+2025-07-19: legal_movesが端の手を生成できずゲームが誤終了する不具合を修正。

--- a/src/othello/board.py
+++ b/src/othello/board.py
@@ -86,16 +86,19 @@ class BitBoard:
         """Return bitboard of legal moves for ``player`` against ``opponent``."""
         empty = self.empty()
         moves = 0
-        for d in DIRS:
-            mask = self._shift(player, d) & opponent
-            while mask:
-                mask = self._shift(mask, d)
-                if mask & player:
-                    break
-                if mask & empty:
-                    moves |= mask & empty
-                    break
-                mask &= opponent
+        candidates = empty
+        while candidates:
+            move = candidates & -candidates
+            for d in DIRS:
+                bb = self._shift(move, d)
+                if bb & opponent:
+                    bb = self._shift(bb, d)
+                    while bb & opponent:
+                        bb = self._shift(bb, d)
+                    if bb & player:
+                        moves |= move
+                        break
+            candidates ^= move
         return moves
 
     def flips(self, move: int, player: int, opponent: int) -> int:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -30,3 +30,22 @@ BBBBBBBB
     )
     assert board.legal_moves(board.black, board.white) == 0
     assert board.legal_moves(board.white, board.black) == 0
+
+
+def test_legal_moves_on_edge_positions():
+    board = BitBoard.from_ascii(
+        """
+........
+...WWW..
+.B.W....
+.BWWWWB.
+.BBBWWB.
+.BBWWWB.
+.BWWBBB.
+.BBBBBW.
+"""
+    )
+    white_moves = board.legal_moves(board.white, board.black)
+    black_moves = board.legal_moves(board.black, board.white)
+    assert white_moves != 0
+    assert black_moves != 0


### PR DESCRIPTION
## Summary
- handle edge cases correctly when computing legal moves
- add regression test for edge moves
- record fix in MEMO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a9fc879b083259e266491194d6d48