### PR TITLE
Fix missing newline at EOF in main

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,3 +5,4 @@ from othello.cli import main
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- ensure `src/main.py` ends with a newline after calling `main()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c680c7fcc8325a5a9f2a2cc4b19df