### PR TITLE
Add CLI options to othello-gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install -e .
 # 対戦を開始
 othello [--ai] [--ai-vs-ai] [--ai-level {easy,hard,expert}] [--time-limit SECS] [--host HOST:PORT | --connect HOST:PORT]
 # GUI 版を起動
-othello-gui
+othello-gui [--vs-ai] [--ai-level {easy,hard,expert}]
 ```
 
 GUI では合法手のハイライトと、無効な操作時にメッセージを表示するステータスラベルを追加しています。

--- a/TODO.md
+++ b/TODO.md
@@ -25,5 +25,5 @@
 - [x] implement get_legal_moves to return coordinates
 - [x] status_label should exist; implement if missing
 - [x] integrate scoreboard view in GUI
-- [ ] expose additional GUI options via CLI
+- [x] expose additional GUI options via CLI
 - [ ] implement robust network error handling with retries and timeouts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ test = [
 
 [project.scripts]
 othello = "othello.cli:play"
-othello-gui = "othello.gui:play_gui"
+othello-gui = "othello.gui:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/othello/gui.py
+++ b/src/othello/gui.py
@@ -4,6 +4,7 @@
 
 import tkinter as tk
 from tkinter import messagebox
+import argparse
 
 # Handle both relative and absolute imports for direct execution
 try:
@@ -128,9 +129,26 @@ class OthelloGUI:
 
 
 def play_gui(vs_ai: bool = False, ai_level: str = "easy") -> None:
-    """Entry point for playing the GUI version."""
+    """Launch the GUI with the provided options."""
     OthelloGUI(vs_ai, ai_level).run()
-# TODO: expose additional GUI options via CLI
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the ``othello-gui`` command."""
+    parser = argparse.ArgumentParser(description="Play Othello with a GUI")
+    parser.add_argument(
+        "--vs-ai", action="store_true", help="Play against the computer"
+    )
+    parser.add_argument(
+        "--ai-level",
+        choices=["easy", "hard", "expert"],
+        default="easy",
+        help="AI difficulty level",
+    )
+    args = parser.parse_args(argv)
+    play_gui(vs_ai=args.vs_ai, ai_level=args.ai_level)
+
+# CHANGED: command line options are now parsed when executing as a script
 
 if __name__ == "__main__":
-    play_gui(vs_ai=True)
+    main()


### PR DESCRIPTION
## Summary
- expose GUI options `--vs-ai` and `--ai-level` via `othello-gui` command
- update entry point and documentation
- mark TODO item as complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870d33c7f508325a5383b721892a046