### PR TITLE
Fix #86: Add proper --help argument handling to dev-setup.sh

### DIFF
--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -4,6 +4,34 @@
 
 set -e
 
+# Handle help argument
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    echo "Usage: $0 [options]"
+    echo "Setup development environment for Othello project"
+    echo ""
+    echo "Options:"
+    echo "  -h, --help    Show this help message and exit"
+    echo ""
+    echo "This script will:"
+    echo "  1. Check Python 3.8+ installation"
+    echo "  2. Create virtual environment"
+    echo "  3. Install dependencies in development mode"
+    echo "  4. Verify installation and entry points"
+    echo "  5. Create development shortcuts (activate_dev.sh, run_tests.sh)"
+    echo "  6. Display quick start guide"
+    echo ""
+    echo "Requirements:"
+    echo "  - Python 3.8 or higher"
+    echo "  - Internet connection for package downloads"
+    echo "  - Write permissions in current directory"
+    echo ""
+    echo "After setup, use:"
+    echo "  source activate_dev.sh    # Activate development environment"
+    echo "  ./run_tests.sh           # Run test suite"
+    echo "  othello --ai             # Play game with AI"
+    exit 0
+fi
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Problem
The development setup script `scripts/dev-setup.sh` did not handle the `--help` argument properly, causing it to run the full setup process instead of showing help text. This led to test timeouts and poor developer experience.

## Test Failure Before Fix
```
tests/test_dev_setup.py::TestDevSetupScript::test_dev_setup_script_help_output
subprocess.TimeoutExpired: Command ['bash', 'scripts/dev-setup.sh', '--help'] timed out after 10 seconds
```

## Solution Implemented
Added argument parsing at the beginning of the script to:
1. **Detect help arguments**: Both `--help` and `-h` are now supported
2. **Display comprehensive help**: Usage, options, requirements, and quick start guide
3. **Exit immediately**: No setup operations are performed when help is requested

## Help Output
```bash
$ ./scripts/dev-setup.sh --help
Usage: ./scripts/dev-setup.sh [options]
Setup development environment for Othello project

Options:
  -h, --help    Show this help message and exit

This script will:
  1. Check Python 3.8+ installation
  2. Create virtual environment
  3. Install dependencies in development mode
  4. Verify installation and entry points
  5. Create development shortcuts (activate_dev.sh, run_tests.sh)
  6. Display quick start guide

Requirements:
  - Python 3.8 or higher
  - Internet connection for package downloads
  - Write permissions in current directory

After setup, use:
  source activate_dev.sh    # Activate development environment
  ./run_tests.sh           # Run test suite
  othello --ai             # Play game with AI
```

## Testing Results
✅ **Fixed test**: `test_dev_setup_script_help_output` now passes (was timing out)  
✅ **All dev-setup tests pass**: 16/16 tests successful  
✅ **No regressions**: Normal script execution unchanged  
✅ **Fast response**: Help displays instantly and exits cleanly  

## Changes Made
- Added help argument detection before any setup operations
- Created informative help text covering all script functionality
- Both `--help` and `-h` work correctly
- Preserves all existing functionality for normal usage

Fixes #86

🤖 Generated with [Claude Code](https://claude.ai/code)